### PR TITLE
Fix for windows os.rename

### DIFF
--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -376,11 +376,10 @@ def update_credentials_file(filename, target_profile, source_profile,
     with open(temp_credentials_file, "w") as out:
         credentials.write(out)
     try:
-		os.rename(temp_credentials_file, filename)
+        os.rename(temp_credentials_file, filename)
     except WindowsError as E:
-		os.remove(filename)
-		with open(filename, "w") as out:
-			credentials.write(out)
+        os.remove(filename)
+        os.rename(temp_credentials_file, filename)
 
 
 if __name__ == '__main__':

--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -375,7 +375,12 @@ def update_credentials_file(filename, target_profile, source_profile,
     temp_credentials_file = filename + ".tmp"
     with open(temp_credentials_file, "w") as out:
         credentials.write(out)
-    os.rename(temp_credentials_file, filename)
+    try:
+		os.rename(temp_credentials_file, filename)
+    except WindowsError as E:
+		os.remove(filename)
+		with open(filename, "w") as out:
+			credentials.write(out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If windows error on the rename just delete the original file and then write out the new one.

On github its showing as double-tabbed but whenever I pull the file down its showing correctly. Can you confirm that? Or did I miss some setting?
