### PR TITLE
Use identity profile when rotating keys

### DIFF
--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -183,7 +183,7 @@ def rotate(args, credentials):
         args.identity_profile, 'aws_access_key_id')
 
     # create new sessions using the MFA credentials
-    session, session3, err = make_session(args.target_profile)
+    session, session3, err = make_session(args.identity_profile)
     if err:
         return err
     iam = session3.resource('iam')


### PR DESCRIPTION
Fixes issue #3: using argument `--rotate-identity-keys` while assuming role would throw an AWS api validation error.