### PR TITLE
Reload credentials before writing to avoid clashes with other processes

### DIFF
--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -363,6 +363,8 @@ def find_mfa_for_user(user_specified_serial, botocore_session, boto3_session):
 
 def update_credentials_file(filename, target_profile, source_profile,
                             credentials, new_access_key):
+    # reload credentials before writing to avoid conflicts with other processes
+    credentials.read(filename)
     if target_profile != source_profile:
         credentials.remove_section(target_profile)
         # Hack: Python 2's implementation of ConfigParser rejects new sections


### PR DESCRIPTION
The credentials file is currently read once in main, and then those
credentials are stored in memory and used as the basis for writing to
the credentials file when update_credentials_file is eventually called.

This allows lots of time for other processes to write to the credentials
file, and awsmfa then obliterates those changes when it writes the file.

There is no easy way to ensure that multiple processes co-operate, but
we can at least reduce the timeframe for clashes, and this commit does
that by simply reloading the credentials before updating and writing.