### PR TITLE
Don't hide token code input, there's no need

### DIFF
--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 from __future__ import print_function
+from builtins import input
 
 import argparse
 import datetime
-import getpass
 import os
 import sys
 
@@ -168,7 +168,7 @@ def acquire_code(args, session, session3):
     token_code = args.token_code
     if token_code is None:
         while token_code is None or len(token_code) != 6:
-            token_code = getpass.getpass("MFA Token Code: ")
+            token_code = input("MFA Token Code: ")
     return serial_number, token_code, OK
 
 


### PR DESCRIPTION
Tokens are one time passwords valid for a very short time window and it
seems standard practice to echo them as entered (e.g. AWS console), as
the risk of exploiting them is low, yet hiding them negatively impacts
the user interface and can complicate code that validates user input.

So, let's make things simple and echo the token as entered, and have
awsmfa behave like the AWS console, not like a unix password prompt.

Note: code should work with python 2 and 3, but only tested on 3.7.5