### PR TITLE
Fix eval of env vars, write prompt to stderr

### DIFF
--- a/awsmfa/__main__.py
+++ b/awsmfa/__main__.py
@@ -168,7 +168,8 @@ def acquire_code(args, session, session3):
     token_code = args.token_code
     if token_code is None:
         while token_code is None or len(token_code) != 6:
-            token_code = input("MFA Token Code: ")
+            sys.stderr.write("MFA Token Code: ")
+            token_code = input()
     return serial_number, token_code, OK
 
 


### PR DESCRIPTION
Sorry, I broke the evaluation of environment variables written to stdout using the --env option by replacing getpass.getpass with builtins.input (getpass prompt is written to stderr, input prompt is written to stdout)